### PR TITLE
Switched email from gmail to sparkpost

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ To start the services locally you will first need to create a `.env` file next t
         EMAIL_HOST_USER=SMTP_Injection
         EMAIL_PORT=587
         EMAIL_HOST_PASSWORD=<Api password need to retrieve from sparkpost>
-        ERROR_EMAIL=<email to recieve reports>
-        ERROR_FROM_EMAIL=error-reports@mantidproject.org   
+        EMAIL_TO_ADDRESS=<email to recieve reports>
+        EMAIL_FROM_ADDRESS=error-reports@mantidproject.org   
 
 The values of each key are irrelevant for the test setup. For production they need to be kept secret. The email enviromental variables may be left out if emailing functionality is not required.
 
@@ -76,8 +76,8 @@ On OSX we can use a `VirtualBox` driver to execute the `Dockerfile`
         EMAIL_HOST_USER=SMTP_Injection
         EMAIL_PORT=587
         EMAIL_HOST_PASSWORD=<Api password need to retrieve from sparkpost>
-        ERROR_EMAIL=<email to recieve reports>
-        ERROR_FROM_EMAIL=error-reports@mantidproject.org
+        EMAIL_TO_ADDRESS=<email to recieve reports>
+        EMAIL_FROM_ADDRESS=error-reports@mantidproject.org
 
 2. Create a virtual machine called `development`
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ To start the services locally you will first need to create a `.env` file next t
         EMAIL_HOST_USER=SMTP_Injection
         EMAIL_PORT=587
         EMAIL_HOST_PASSWORD=<Api password need to retrieve from sparkpost>
-        ERROR_EMAIL=<email to recieve reports>   
+        ERROR_EMAIL=<email to recieve reports>
+        ERROR_FROM_EMAIL=error-reports@mantidproject.org   
 
 The values of each key are irrelevant for the test setup. For production they need to be kept secret. The email enviromental variables may be left out if emailing functionality is not required.
 
@@ -76,6 +77,7 @@ On OSX we can use a `VirtualBox` driver to execute the `Dockerfile`
         EMAIL_PORT=587
         EMAIL_HOST_PASSWORD=<Api password need to retrieve from sparkpost>
         ERROR_EMAIL=<email to recieve reports>
+        ERROR_FROM_EMAIL=error-reports@mantidproject.org
 
 2. Create a virtual machine called `development`
 

--- a/web/celery_app/tasks.py
+++ b/web/celery_app/tasks.py
@@ -18,7 +18,7 @@ def send_notification_email(name, email, text_box):
 
     send_mail(subject,
               message,
-              'error-reports@mantidproject.org',
+              settings.ERROR_FROM_EMAIL,
               to_address,
               fail_silently=False,
               )

--- a/web/celery_app/tasks.py
+++ b/web/celery_app/tasks.py
@@ -10,13 +10,15 @@ def send_notification_email(name, email, text_box):
 
     message = (
         'An error report has been submitted by {}'
-        ' who provided the following email {}. The '
-        'following information was sent {}'
+        ' who provided the following email {}. '
+        '\nThe following information was sent:\n\n {}' 
+        '\n'
+        '\n https://errorreports.mantidproject.org/admin/'
     ).format(name, email, text_box)
 
     send_mail(subject,
               message,
-              'mantidproject@gmail.com',
+              'error-reports@mantidproject.org',
               to_address,
               fail_silently=False,
               )

--- a/web/celery_app/tasks.py
+++ b/web/celery_app/tasks.py
@@ -11,7 +11,7 @@ def send_notification_email(name, email, text_box):
     message = (
         'An error report has been submitted by {}'
         ' who provided the following email {}. '
-        '\nThe following information was sent:\n\n {}' 
+        '\nThe following information was sent:\n\n {}'
         '\n'
         '\n https://errorreports.mantidproject.org/admin/'
     ).format(name, email, text_box)

--- a/web/celery_app/tasks.py
+++ b/web/celery_app/tasks.py
@@ -5,7 +5,8 @@ from django.conf import settings
 
 @shared_task
 def send_notification_email(name, email, text_box):
-    to_address = [settings.ERROR_EMAIL]
+    to_address = [settings.EMAIL_TO_ADDRESS]
+    from_address = settings.EMAIL_FROM_ADDRESS
     subject = 'User error report'
 
     message = (
@@ -18,7 +19,7 @@ def send_notification_email(name, email, text_box):
 
     send_mail(subject,
               message,
-              settings.ERROR_FROM_EMAIL,
+              from_address,
               to_address,
               fail_silently=False,
               )

--- a/web/services/models.py
+++ b/web/services/models.py
@@ -56,11 +56,15 @@ class RecoveryFiles(models.Model):
 
 
 def send_email_notification(sender, instance, signal, *args, **kwargs):
-    name = instance.user.name if instance.user and instance.user.name != 'public_name' else ''
-    email = instance.user.email if instance.user and instance.user.email != 'public_email' else ''
-    text_box = instance.textBox if instance.textBox and instance.textBox != 'Something went wrong' else ''
+    name = instance.user.name if instance.user and \
+        instance.user.name != 'public_name' else ''
+    email = instance.user.email if instance.user and \
+        instance.user.email != 'public_email' else ''
+    text_box = instance.textBox if instance.textBox and \
+        instance.textBox != 'Something went wrong' else ''
 
     if name or email or text_box:
         send_notification_email.delay(name, email, text_box)
+
 
 signals.post_save.connect(send_email_notification, sender=ErrorReport)

--- a/web/services/models.py
+++ b/web/services/models.py
@@ -62,14 +62,12 @@ class RecoveryFiles(models.Model):
 
 
 def send_email_notification(sender, instance, signal, *args, **kwargs):
-    name = instance.user.name if instance.user and \
-        instance.user.name != test_name else ''
+    name = instance.user.name if instance.user else ''
     email = instance.user.email if instance.user and \
         instance.user.email != test_email else ''
-    text_box = instance.textBox if instance.textBox and \
-        instance.textBox != test_info else ''
+    text_box = instance.textBox
 
-    if name or email or text_box:
+    if email:
         send_notification_email.delay(name, email, text_box)
 
 

--- a/web/services/models.py
+++ b/web/services/models.py
@@ -56,11 +56,11 @@ class RecoveryFiles(models.Model):
 
 
 def send_email_notification(sender, instance, signal, *args, **kwargs):
-    name = instance.user.name if instance.user else ''
-    email = instance.user.email if instance.user else ''
-    text_box = instance.textBox
+    name = instance.user.name if instance.user and instance.user.name != 'public_name' else ''
+    email = instance.user.email if instance.user and instance.user.email != 'public_email' else ''
+    text_box = instance.textBox if instance.textBox and instance.textBox != 'Something went wrong' else ''
+
     if name or email or text_box:
         send_notification_email.delay(name, email, text_box)
-
 
 signals.post_save.connect(send_email_notification, sender=ErrorReport)

--- a/web/services/models.py
+++ b/web/services/models.py
@@ -6,6 +6,9 @@ from django.db.models import signals
 from celery_app.tasks import send_notification_email
 
 fs = FileSystemStorage(location=settings.MEDIA_ROOT)
+test_email = 'public_email'
+test_name = 'public_name'
+test_info = 'Something went wrong'
 
 
 class ErrorReport(models.Model):
@@ -57,11 +60,11 @@ class RecoveryFiles(models.Model):
 
 def send_email_notification(sender, instance, signal, *args, **kwargs):
     name = instance.user.name if instance.user and \
-        instance.user.name != 'public_name' else ''
+        instance.user.name != test_name else ''
     email = instance.user.email if instance.user and \
-        instance.user.email != 'public_email' else ''
+        instance.user.email != test_email else ''
     text_box = instance.textBox if instance.textBox and \
-        instance.textBox != 'Something went wrong' else ''
+        instance.textBox != test_info else ''
 
     if name or email or text_box:
         send_notification_email.delay(name, email, text_box)

--- a/web/settings.py
+++ b/web/settings.py
@@ -148,8 +148,8 @@ if DEBUG:
     }
 
 EMAIL_USE_TLS = True
-EMAIL_HOST = 'smtp.gmail.com'
-EMAIL_HOST_USER = 'mantidproject@gmail.com'
+EMAIL_HOST = os.getenv('EMAIL_HOST', '')
+EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER', '')
 EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD', '')
 EMAIL_PORT = os.getenv('EMAIL_PORT', '')
 ERROR_EMAIL = os.getenv('ERROR_EMAIL', '')

--- a/web/settings.py
+++ b/web/settings.py
@@ -152,8 +152,8 @@ EMAIL_HOST = os.getenv('EMAIL_HOST', '')
 EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER', '')
 EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD', '')
 EMAIL_PORT = os.getenv('EMAIL_PORT', '')
-ERROR_EMAIL = os.getenv('ERROR_EMAIL', '')
-ERROR_FROM_EMAIL = os.getenv('ERROR_FROM_EMAIL', '')
+EMAIL_TO_ADDRESS = os.getenv('EMAIL_TO_ADDRESS', '')
+EMAIL_FROM_ADDRESS = os.getenv('EMAIL_FROM_ADDRESS', '')
 
 CELERY_BROKER_URL = 'redis://redis:6379'
 CELERY_RESULT_BACKEND = 'redis://redis:6379'

--- a/web/settings.py
+++ b/web/settings.py
@@ -153,6 +153,7 @@ EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER', '')
 EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD', '')
 EMAIL_PORT = os.getenv('EMAIL_PORT', '')
 ERROR_EMAIL = os.getenv('ERROR_EMAIL', '')
+ERROR_FROM_EMAIL = os.getenv('ERROR_FROM_EMAIL', '')
 
 CELERY_BROKER_URL = 'redis://redis:6379'
 CELERY_RESULT_BACKEND = 'redis://redis:6379'


### PR DESCRIPTION
This PR switches the email client used to spark, it also updates the email message to contain a link to the errorreport service and filters out the names and email used by the system test so that email notifications are not sent for this.