### PR TITLE
Updated redis version

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -6,4 +6,4 @@ gunicorn
 gevent
 psycopg2-binary
 celery==4.2.1
-redis==2.10.6
+redis==3.2.1


### PR DESCRIPTION
The redis version was outdated which was leading to a failure when a report including an email was sent. This updates the version to resolve the issue