### PR TITLE
Add log file handler for production environment

### DIFF
--- a/web/settings.py
+++ b/web/settings.py
@@ -146,6 +146,28 @@ if DEBUG:
             },
         },
     }
+else:
+    LOGGING = {
+        'version': 1,
+        'disable_existing_loggers': False,
+        'handlers': {
+            'logfile': {
+                'level': 'ERROR',
+                'class': 'logging.handlers.RotatingFileHandler',
+                'filename': '/var/log/django.log',
+                'maxBytes': 1024*1024*15,  # 15MB
+                'backupCount': 10,
+            },
+        },
+        'loggers': {
+            'django': {
+                'handlers': ['logfile'],
+                'level': 'ERROR',
+            },
+
+        },
+    }
+
 
 EMAIL_USE_TLS = True
 EMAIL_HOST = os.getenv('EMAIL_HOST', '')


### PR DESCRIPTION
**Description**

Error-level logging in production was being swallowed by django and it was impossible to tell what had happened. This adds a file handler so that any `ERROR` level reports are written to this file.

**Testing**

* Put a test file called `.env` in the root of the checkout containing:
```
DB_NAME=django
DB_USER=django
DB_PASS=default
HOST_PORT=8082
```
* Add a random `raise RuntimeError("ERROR")` to the code somewhere, e.g `web/services/views.py:131`
* Start the error reporter with `bin/boot.sh`.
* In `Mantid.user.properties` add `errorreports.rooturl = http://localhost:8082`
* Run `./systemtest -R ErrorReporter` and it should fail with a 500 error.
* Run `docker exec -it errorreports_web_1 cat /var/log/django.log` and you should see the traceback from the error.