### PR TITLE
Replace email notifications with Slack

### DIFF
--- a/web/celery_app/tasks.py
+++ b/web/celery_app/tasks.py
@@ -1,30 +1,35 @@
-from django.core.mail import send_mail
-from celery import shared_task
 from django.conf import settings
+import requests
+
+from celery import shared_task
 
 
 @shared_task
-def send_notification_email(name, email, text_box):
-    to_address = [settings.EMAIL_TO_ADDRESS]
-    from_address = settings.EMAIL_FROM_ADDRESS
-    subject = 'User error report'
+def send_notification_to_slack(name, email, additional_text):
+    """Sends a notification about a new error report to the slack
+    channel defined in the settings
 
-    message = (
-        'An error report has been submitted by {}'
-        ' who provided the following email {}. '
-        '\nThe following information was sent:\n\n {}'
-        '\n'
-        '\n https://errorreports.mantidproject.org/admin/'
-    ).format(name, email, text_box)
-
-    send_mail(subject,
-              message,
-              from_address,
-              to_address,
-              fail_silently=False,
-              )
-
-
-@shared_task
-def hello():
-    print('Hello there')
+    :param name: The name field supplied in the error report
+    :param email: The email address supplied in the error report.
+                  This is required.
+    :param additional_text: Any additional text provided
+    """
+    slack_webhook_url = settings.SLACK_WEBHOOK_URL
+    if slack_webhook_url is None:
+        return
+    text = """An error report was received. Details:
+        Name: {}
+        Email: {}
+        Additional text:
+        {}
+    """.format(
+        name if name else settings.SLACK_ERROR_REPORTS_EMPTY_FIELD_TEXT, email,
+        additional_text
+        if additional_text else settings.SLACK_ERROR_REPORTS_EMPTY_FIELD_TEXT)
+    requests.post(slack_webhook_url,
+                  json={
+                      'channel': settings.SLACK_ERROR_REPORTS_CHANNEL,
+                      'username': settings.SLACK_ERROR_REPORTS_USERNAME,
+                      'text': text,
+                      'icon_emoji': settings.SLACK_ERROR_REPORTS_EMOJI
+                  })

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -7,3 +7,4 @@ gevent
 psycopg2-binary
 celery==4.2.1
 redis==3.2.1
+requests==2.22.0

--- a/web/settings.py
+++ b/web/settings.py
@@ -59,7 +59,6 @@ MIDDLEWARE_CLASSES = (
 
 ROOT_URLCONF = 'urls'
 
-
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -118,7 +117,6 @@ USE_L10N = True
 
 USE_TZ = True
 
-
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 
@@ -147,13 +145,16 @@ if DEBUG:
         },
     }
 
-EMAIL_USE_TLS = True
-EMAIL_HOST = os.getenv('EMAIL_HOST', '')
-EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER', '')
-EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD', '')
-EMAIL_PORT = os.getenv('EMAIL_PORT', '')
-EMAIL_TO_ADDRESS = os.getenv('EMAIL_TO_ADDRESS', '')
-EMAIL_FROM_ADDRESS = os.getenv('EMAIL_FROM_ADDRESS', '')
+# Slack notifications can be configured by environment variables
+# webhook is required, everything else is optional
+SLACK_WEBHOOK_URL = os.getenv('SLACK_WEBHOOK_URL', None)
+SLACK_ERROR_REPORTS_CHANNEL = os.getenv('SLACK_ERROR_REPORTS_CHANNEL',
+                                        '#error-reports')
+SLACK_ERROR_REPORTS_USERNAME = os.getenv('SLACK_ERROR_REPORTS_USERNAME',
+                                         'Error Reporter')
+SLACK_ERROR_REPORTS_EMOJI = os.getenv('SLACK_ERROR_REPORTS_EMOJI', ':skull:')
+SLACK_ERROR_REPORTS_EMPTY_FIELD_TEXT = os.getenv(
+    'SLACK_ERROR_REPORTS_EMPTY_FIELD_TEXT', 'Not provided')
 
 CELERY_BROKER_URL = 'redis://redis:6379'
 CELERY_RESULT_BACKEND = 'redis://redis:6379'


### PR DESCRIPTION
**Description**

Slack's webhooks make posting messages to channels very simple. This change replaces the current email notifier with a slack-based one.

**Testing**

* Put a test file called `.env` in the root of the checkout containing:
```
DB_NAME=django
DB_USER=django
DB_PASS=default
HOST_PORT=8082
SLACK_WEBHOOK_URL=<GET-HOOK-URL-FROM-SLACK>
SLACK_ERROR_REPORTS_CHANNEL=#error-reports
SLACK_ERROR_REPORTS_USERNAME=Error Reporter
SLACK_ERROR_REPORTS_EMOJI=:skull:
SLACK_ERROR_REPORTS_EMPTY_FIELD_TEXT=Not provided
```
* Start the error reporter with `bin/boot.sh`.
* In `Mantid.user.properties` add `errorreports.rooturl = http://localhost:8082`
* Start MantidPlot, cause a segfault and provide an email. There should be a notification to the mantid Slack #error-reports channel.