### PR TITLE
Add external named network for upstream server

### DIFF
--- a/bin/boot.sh
+++ b/bin/boot.sh
@@ -5,6 +5,12 @@ function mk_django_secret() {
   python -c "import random,string;print('%s'%''.join([random.SystemRandom().choice(\"{}{}{}\".format(string.ascii_letters, string.digits, string.punctuation)) for i in range(63)]))";
 }
 
+function create_external_net(){
+  network_name=nginx_net
+  docker network inspect nginx_net >/dev/null 2>&1 || \
+    docker network create --driver bridge nginx_net
+}
+
 SCRIPTPATH=$(cd "$(dirname "$0")"; pwd -P)
 SOURCE_DIR=$(cd "$SCRIPTPATH" && cd .. && pwd -P)
 PROJECT_NAME=errorreports
@@ -53,6 +59,8 @@ if [ ! -f ${SOURCE_DIR}/.env ]; then
   exit 1
 fi
 
+# Start external network
+create_external_net
 # Build services
 docker-compose ${COMPOSE_FILES} --project-name ${PROJECT_NAME} build
 # Bring up the stack and detach

--- a/bin/boot.sh
+++ b/bin/boot.sh
@@ -2,7 +2,7 @@
 # Starts the stack
 
 function mk_django_secret() {
-  python -c "import random,string;print('%s'%''.join([random.SystemRandom().choice(\"{}{}{}\".format(string.ascii_letters, string.digits, string.punctuation)) for i in range(63)]))";
+  python3 -c "import random,string;print('%s'%''.join([random.SystemRandom().choice(\"{}{}{}\".format(string.ascii_letters, string.digits, string.punctuation)) for i in range(63)]))";
 }
 
 function create_external_net(){

--- a/bin/shutdown.sh
+++ b/bin/shutdown.sh
@@ -13,3 +13,5 @@ docker-compose down
 # come from an image
 echo "Removing webdata volume so it is rebuilt on next startup"
 docker volume rm ${PROJECT_NAME}_webdata
+echo "Removing external network nginx_net"
+docker network rm nginx_net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - MAIL_PORT
       - ERROR_EMAIL
 
-  nginx:
+  nginx_errorreports:
     restart: always
     build: ./nginx/
     env_file: .env
@@ -54,8 +54,16 @@ services:
       - "${HOST_PORT}:80"
     volumes:
       - webdata:/usr/src/app
+    networks:
+      - default
+      - nginx_net
 
 volumes:
   webdata:
   # If this is changed remember to run the bin/shutdown.sh then bin/boot.sh script
   pgdata:
+
+networks:
+
+  nginx_net:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - MAIL_PORT
       - ERROR_EMAIL
 
-  nginx_errorreports:
+  nginx-errorreports:
     restart: always
     build: ./nginx/
     env_file: .env


### PR DESCRIPTION
Adds the external named network nginx_net so that the server can
internally route without going via the host. Additionally names the
nginx container to nginx_errorreports, so we can tell via hostname