### PR TITLE
Show User in Django database

### DIFF
--- a/DevelopmentSetup.md
+++ b/DevelopmentSetup.md
@@ -189,6 +189,14 @@ docker-compose exec web python manage.py createsuperuser
 and enter the requested details. Once the account has been created go to
 `http://localhost:<HOST_PORT>/admin` and login with the details you provided.
 
+## Shutdown the Server
+
+When finished with the server, from the root of your source directory, you can shut it down:
+
+```sh
+bash bin/shutdown.sh
+```
+
 ## Troubleshooting
 
 If you are having problems connecting to the localhost with an obscure error code, try
@@ -196,9 +204,4 @@ add the ``DEBUG=True`` variable to your ``.env`` file. This will provide a bette
 error message to help you debug the problem.
 
 An error about invalid credentials could be caused by persisting data from a previous
-time you have looked at this repo. To clear any persisting data, run the following
-command:
-
-```sh
-bash bin/shutdown.sh
-```
+time you have looked at this repo. To clear any persisting data, run the shutdown script.

--- a/DevelopmentSetup.md
+++ b/DevelopmentSetup.md
@@ -129,7 +129,7 @@ in the right location.
 Clone this repository locally:
 
 ```sh
-> git clone https://github.com/mantidproject/reports.git
+> git clone https://github.com/mantidproject/errorreports.git
 ```
 
 ## Creating an Environment (.env) File

--- a/bin/shutdown.sh
+++ b/bin/shutdown.sh
@@ -13,6 +13,7 @@ docker-compose down
 # come from an image
 echo "Removing webdata volume so it is rebuilt on next startup"
 rm -r "${SOURCE_DIR}/webdata"
+docker volume rm errorreports_webdata
 
 echo "Removing external network nginx_net"
 docker network rm nginx_net

--- a/web/services/admin.py
+++ b/web/services/admin.py
@@ -1,4 +1,6 @@
 from django.contrib import admin
+from django.urls import reverse
+from django.utils.safestring import mark_safe   
 # Register your models here.
 from services.models import ErrorReport, UserDetails
 
@@ -15,13 +17,15 @@ class ErrorAdmin(admin.ModelAdmin):
         'exitCode',
         'upTime',
         'textBox',
-        'get_user_email',
+        'user_link',
         'stacktrace')
 
-    def get_user_email(self, obj):
-        return obj.user.email if obj.user else ''
-    get_user_email.admin_order_field = 'user__email'
-    get_user_email.short_description = 'User provided email'
+    def user_link(self, obj):
+        return mark_safe('<a href="{}">{}</a>'.format(
+            reverse("admin:services_userdetails_change", args=(obj.user.pk,)),
+            obj.user.email
+        ))
+    user_link.short_description = 'User'
 
 
 class UserAdmin(admin.ModelAdmin):

--- a/web/settings.py
+++ b/web/settings.py
@@ -25,6 +25,8 @@ SECRET_KEY = os.environ['SECRET_KEY']
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv('DEBUG', 'NO').lower() in ('on', 'true', 'y', 'yes')
 
+DEFAULT_AUTO_FIELD='django.db.models.BigAutoField'
+
 ALLOWED_HOSTS = ['*']
 
 MEDIA_ROOT = '/usr/src/app/recovery'


### PR DESCRIPTION
**Description**
This PR changes the displayed data in the django admin database. Instead of showing a 'User provided email', it instead displays a link to the user who sent the report. This provides a quick and convenient way to view the email and name of the user without displaying too much unnecessary data in the one table.

I also added a short doc change to say to shutdown the server when you are finished. The shutdown script should also be used to remove a volume for python changes to be recognised when re-booting.

And finally this fixes a warning by setting the `DEFAULT_AUTO_FILL` variable in the settings.py file.

Fixes #32