### PR TITLE
Added postgres data removal step

### DIFF
--- a/DevelopmentSetup.md
+++ b/DevelopmentSetup.md
@@ -189,12 +189,20 @@ docker-compose exec web python manage.py createsuperuser
 and enter the requested details. Once the account has been created go to
 `http://localhost:<HOST_PORT>/admin` and login with the details you provided.
 
-## Shutdown the Server
+If this step fails then see section below on Shutdown the Server and remove postgres volume.
+
+## Shutdown the Server and remove postgres volume
 
 When finished with the server, from the root of your source directory, you can shut it down:
 
 ```sh
 bash bin/shutdown.sh
+```
+
+If you are testing this locally and NOT on the production server you will also need to remove some persisting postgres data.
+Not removing this data will provent you from running the Django Admin Account step above. To remove the data run
+```sh
+sudo rm -rf pgdata/
 ```
 
 ## Troubleshooting

--- a/DevelopmentSetup.md
+++ b/DevelopmentSetup.md
@@ -189,7 +189,7 @@ docker-compose exec web python manage.py createsuperuser
 and enter the requested details. Once the account has been created go to
 `http://localhost:<HOST_PORT>/admin` and login with the details you provided.
 
-If this step fails then see section below on Shutdown the Server and remove postgres volume.
+If this step fails then see the section below on Shutdown the Server and remove postgres volume.
 
 ## Shutdown the Server and remove postgres volume
 

--- a/DevelopmentSetup.md
+++ b/DevelopmentSetup.md
@@ -200,7 +200,7 @@ bash bin/shutdown.sh
 ```
 
 If you are testing this locally and NOT on the production server you will also need to remove some persisting postgres data.
-Not removing this data will provent you from running the Django Admin Account step above. To remove the data run
+Not removing this data will prevent you from running the Django Admin Account step above. To remove the data run
 ```sh
 sudo rm -rf pgdata/
 ```


### PR DESCRIPTION
When trying to test changes locally we have found that the postgres data needs to be removed otherwise testing in future will not work. The documents have been updated to reflect this. However this step should not be done on the production server.