### PR TITLE
Add postgres healthcheck

### DIFF
--- a/DevelopmentSetup.md
+++ b/DevelopmentSetup.md
@@ -201,6 +201,7 @@ bash bin/shutdown.sh
 
 If you are testing this locally and NOT on the production server you will also need to remove some persisting postgres data.
 Not removing this data will prevent you from running the Django Admin Account step above. To remove the data run
+
 ```sh
 sudo rm -rf pgdata/
 ```
@@ -213,3 +214,18 @@ error message to help you debug the problem.
 
 An error about invalid credentials could be caused by persisting data from a previous
 time you have looked at this repo. To clear any persisting data, run the shutdown script.
+
+## Known issues
+
+### Warnings in docker logs when applying migrations
+
+If the `./pgdata` directory does not exist, i.e. when starting the services
+for the very first time, you will see warnings from Django such as
+
+```sh
+makemigrations.py:105: RuntimeWarning: Got an error checking a consistent migration history performed for database connection 'default': connection to server at "postgres" (192.168.128.2), port 5432 failed: Connection refused
+   Is the server running on that host and accepting TCP/IP connections?
+```
+
+This is expected as the app has not been initialized yet so the DB does not
+exist. The script will continue as expected.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ services:
       DB_SERVICE: ${DB_SERVICE}
       DB_PORT: ${DB_PORT}
       SECRET_KEY: ${SECRET_KEY}
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   adminer:
     image: adminer
@@ -32,7 +37,8 @@ services:
       # Change the value in the nginx configuration if this is changed
       - "8000"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     env_file: .env
     environment:
       DB_SERVICE: ${DB_SERVICE}

--- a/web/run_django.sh
+++ b/web/run_django.sh
@@ -1,9 +1,23 @@
 #!/bin/sh
 
-# Initialize the database layers
+# Collect static files into location shared by nginx
+echo "Running collectstatic..."
 python manage.py collectstatic --noinput
+echo "Fixing permissions on /usr/src/app/static"
 chmod 755 -R /usr/src/app/static
+
+# Create any new DB migrations and apply those in version control.
+# Note that running this script for the very first time produces
+# Django warnings such as for both makemigrations and migrate:
+#
+#   makemigrations.py:105: RuntimeWarning: Got an error checking a consistent migration history performed for database connection 'default': connection to server at "postgres" (192.168.128.2), port 5432 failed: Connection refused
+#   Is the server running on that host and accepting TCP/IP connections?
+#
+# This is expected as the app has not been initialized yet so the DB does not
+# exist.
+echo "Running makemigrations..."
 python manage.py makemigrations --noinput
+echo "Running migrate..."
 python manage.py migrate --noinput
 
 # If running in DEBUG mode add debug logging to gunicorn


### PR DESCRIPTION
When starting the services for the first time I was very confused by some output:

```sh
makemigrations.py:105: RuntimeWarning: Got an error checking a consistent migration history performed for database connection 'default': connection to server at "postgres" (192.168.128.2), port 5432 failed: Connection refused
   Is the server running on that host and accepting TCP/IP connections?
```

and assuming the migrations were failing. In fact it was the very first time the script had run so Django had not
yet created the database tables so it failed but the warning looks like the postgres service is not accessible.

By default docker-compose depends_on only waits for a service to be up and the service may not be
ready for connections. The web service now waits for postgres
to be healthy as defined by the new healthcheck.