### PR TITLE
Upgrade Django version to 5.1.10

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,5 +1,5 @@
-Django==5.0
-djangorestframework==3.16.0
+Django==5.1.10
+djangorestframework==3.16.1
 django-filter==25.1
 Markdown
 gunicorn

--- a/web/services/views.py
+++ b/web/services/views.py
@@ -25,7 +25,7 @@ class WithinDateFilter(django_filters.DateFilter):
         if value:
             # date_value = value.replace(hour=0, minute=0, second=0)
             filter_lookups = {
-                "%s__range" % (self.name,): (
+                "%s__range" % (self.field_name,): (
                     value,
                     value + timedelta(days=1),
                 ),
@@ -39,17 +39,17 @@ class MD5Filter(django_filters.CharFilter):
         if value:
             if len(value) != 32:
                 value = hashlib.md5(value).hexdigest()
-            filter_lookups = {self.name: value}
+            filter_lookups = {self.field_name: value}
             queryset = queryset.filter(**filter_lookups)
         return queryset
 
 
 class ErrorFilter(django_filters.FilterSet):
-    date = WithinDateFilter(name="dateTime")
-    datemin = django_filters.DateFilter(name="dateTime", lookup_expr="gte")
-    datemax = django_filters.DateFilter(name="dateTime", lookup_expr="lt")
-    uid = MD5Filter(name="uid")
-    host = MD5Filter(name="host")
+    date = WithinDateFilter(field_name="dateTime")
+    datemin = django_filters.DateFilter(field_name="dateTime", lookup_expr="gte")
+    datemax = django_filters.DateFilter(field_name="dateTime", lookup_expr="lt")
+    uid = MD5Filter(field_name="uid")
+    host = MD5Filter(field_name="host")
 
     class Meta:
         model = ErrorReport

--- a/web/settings.py
+++ b/web/settings.py
@@ -193,3 +193,6 @@ SLACK_ERROR_REPORTS_EMPTY_FIELD_TEXT = os.getenv(
 
 # CSRF trusted origins
 CSRF_TRUSTED_ORIGINS = os.getenv("DJANGO_CSRF_TRUSTED_ORIGINS", "").split(",")
+
+# To direct django admin login into the built-in admin login page
+LOGIN_URL = '/admin/login/'

--- a/web/settings.py
+++ b/web/settings.py
@@ -195,4 +195,4 @@ SLACK_ERROR_REPORTS_EMPTY_FIELD_TEXT = os.getenv(
 CSRF_TRUSTED_ORIGINS = os.getenv("DJANGO_CSRF_TRUSTED_ORIGINS", "").split(",")
 
 # To direct django admin login into the built-in admin login page
-LOGIN_URL = '/admin/login/'
+LOGIN_URL = "/admin/login/"

--- a/web/urls.py
+++ b/web/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import include
 from django.contrib import admin
 from django.views.generic.base import RedirectView
 from django.urls import path
+from views import DRFLoginView
 
 admin.autodiscover()
 
@@ -10,6 +11,8 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("services.urls")),
     # should be in services/urls.py
-    path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
-    path("", RedirectView.as_view(url="/api/", permanent=True)),
+    path('api-auth/login/', DRFLoginView.as_view(), name="rest_login"),
+    path('api-auth/', include('rest_framework.urls',
+                              namespace='rest_framework')),
+    path('', RedirectView.as_view(url='/api/', permanent=True))
 ]

--- a/web/urls.py
+++ b/web/urls.py
@@ -11,8 +11,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("services.urls")),
     # should be in services/urls.py
-    path('api-auth/login/', DRFLoginView.as_view(), name="rest_login"),
-    path('api-auth/', include('rest_framework.urls',
-                              namespace='rest_framework')),
-    path('', RedirectView.as_view(url='/api/', permanent=True))
+    path("api-auth/login/", DRFLoginView.as_view(), name="rest_login"),
+    path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
+    path("", RedirectView.as_view(url="/api/", permanent=True)),
 ]

--- a/web/views.py
+++ b/web/views.py
@@ -1,5 +1,17 @@
-from django.shortcuts import render_to_response
-
+from django.shortcuts import render
+from django.contrib.auth.views import LoginView
 
 def home(request):
-    return render_to_response("home/home.html")
+    return render(request, 'home/home.html')
+
+class DRFLoginView(LoginView):
+    template_name = "rest_framework/login.html"
+
+    def get(self, request, *args, **kwargs):
+        context = {
+            'form': self.get_form(),
+            'next': request.GET.get('next', ''),
+            'name': 'Login',
+            'code_style': 'friendly',
+        }
+        return render(request, self.template_name, context)

--- a/web/views.py
+++ b/web/views.py
@@ -1,17 +1,19 @@
 from django.shortcuts import render
 from django.contrib.auth.views import LoginView
 
+
 def home(request):
-    return render(request, 'home/home.html')
+    return render(request, "home/home.html")
+
 
 class DRFLoginView(LoginView):
     template_name = "rest_framework/login.html"
 
     def get(self, request, *args, **kwargs):
         context = {
-            'form': self.get_form(),
-            'next': request.GET.get('next', ''),
-            'name': 'Login',
-            'code_style': 'friendly',
+            "form": self.get_form(),
+            "next": request.GET.get("next", ""),
+            "name": "Login",
+            "code_style": "friendly",
         }
         return render(request, self.template_name, context)


### PR DESCRIPTION
This PR captures changes required to upgrade Django version from 5.0 -> 5.1.10 to address the security vulnerabilities reported by Dependabot. 

**Test instructions**:
Test the changes by deploying the errorreports service into the staging server via ansible-linode repository.
1. update the [env.j2](https://github.com/mantidproject/ansible-linode/blob/main/roles/errorreports/templates/env.j2) template file with correct credentials for the errorreports service
2. specify the name of this branch at https://github.com/mantidproject/ansible-linode/blob/main/roles/errorreports/tasks/main.yml#L5 
3. Run below playbook targetting staging server and enter the password for `Staging Certs Ansible Vault` when prompted
```
ansible-playbook -i server_staging.yml playbooks/update.yml -t errorreports --ask-vault-pass
```
4. Check docker logs of the 4 services related to error reporter service and confirm there are no errors present
5. Access error reporter admin accounts and adminer accounts via below urls without any issue.
https://errorreports.a.staging-mantidproject.stfc.ac.uk/admin
https://errorreports.a.staging-mantidproject.stfc.ac.uk/api-auth/login/
https://errorreports.a.staging-mantidproject.stfc.ac.uk/adminer
7. Update below in Mantid.properties file in your mantid install
```
errorreports.rooturl = https://errorreports.a.staging-mantidproject.stfc.ac.uk
````
8. Test sending an error report and observe the DB and Docker logs of the error reporter service to confirm they all work seamlessly as expected. The submitted records should enter the DB without any issues.

closes #63 